### PR TITLE
Refactor using OAuth2

### DIFF
--- a/rdio.js
+++ b/rdio.js
@@ -9,60 +9,58 @@
  *	Homepage: http://github.com/dawnerd/
  *	License: MIT
  *
- *
- *	Config options:
- *		rdio_api_key
- *		rdio_api_shared
- *		callback_url - URL user will be redirected to upon login
  */
 
-module.exports = function(config, oauth) {
-	if(typeof oauth == 'undefined') {
-		oauth = require('oauth').OAuth;
-	}
-	
-	config.rdio_oauth_request = 'http://api.rdio.com/oauth/request_token';
-	config.rdio_oauth_access = 'http://api.rdio.com/oauth/access_token';
-	config.rdio_oauth_auth = 'https://www.rdio.com/oauth/authorize?oauth_token=';
-	config.rdio_api = 'http://api.rdio.com/1/';
-	
-	//setup oauth
-	var oa = new oauth(
-		config.rdio_oauth_request,
-		config.rdio_oauth_access, 
-		config.rdio_api_key,
-		config.rdio_api_shared, 
-		"1.0", config.callback_url, "HMAC-SHA1");
-	
-	//public methods	
-	return {
-		getRequestToken: function(callback) {
-			oa.getOAuthRequestToken(callback);
-		},
-		getAccessToken: function(auth_token, auth_token_secret, oauth_verifier, callback) {
-			oa.getOAuthAccessToken(auth_token, auth_token_secret, oauth_verifier, callback);
-		},
-		getPlaybackToken: function(auth_token, auth_token_secret, host, callback) {
-			this.api(
-				auth_token,
-				auth_token_secret,
-				{
-					method: 'getPlaybackToken',
-					domain: encodeURIComponent(host)
-				},
-				callback
-			);
-		},
-		
-		api: function(auth_token, auth_token_secret, data, callback) {
-			oa.post(
-				config.rdio_api,
-				auth_token,
-				auth_token_secret,
-				data,
-				null,
-				callback
-			);
-		}
-	};
+var extend = require('util')._extend;
+var querystring = require('querystring');
+
+var OAuth2 = require('oauth').OAuth2;
+
+var Rdio = function(config) {
+  extend(this, config);
+
+  this.oauth2 = new OAuth2(
+    this.clientId,
+    this.clientSecret,
+    'https://services.rdio.com/',
+    null,
+    'oauth2/token',
+    null
+  );
+}
+
+Rdio.prototype.login = function(callback) {
+  var self = this;
+
+  this.oauth2.getOAuthAccessToken(this.refreshToken, {
+    grant_type: 'refresh_token',
+  }, function(err, accessToken, refreshToken) {
+    if (err) return callback((err.data) ? new Error(JSON.parse(err.data).error_description) : err);
+    self.accessToken = accessToken;
+    self.refreshToken = refreshToken;
+    callback();
+  });
+}
+
+Rdio.prototype.call = function(method, args, callback) {
+  if (typeof args === 'function') {
+    callback = args;
+    args = {};
+  }
+
+  var headers = {
+    'Authorization': this.oauth2.buildAuthHeader(this.accessToken),
+    'Content-Type': 'application/x-www-form-urlencoded',
+  };
+
+  var data = querystring.stringify(extend(args, {method: method}));
+
+  this.oauth2._request('POST', 'https://services.rdio.com/api/1/', headers, data, null, function(err, data) {
+    if (err) return callback((err.data) ? new Error(JSON.parse(err.data).error_description) : err);
+    data = JSON.parse(data);
+    if (data.status !== 'ok') return callback(new Error(data.message));
+    callback(null, data.result);
+  });
 };
+
+module.exports = Rdio;


### PR DESCRIPTION
On June 30th Rdio disabled OAuth 1 authentication and forced OAuth 2 to use their API, making the current node-rdio module unusable.

This breaks compatibility with previous version of node-rdio.

The authentication change is a breaking change to the previous module. So I also purposely refactored the module as a whole. Here is an example of new usage:

``` js
var Rdio = require('rdio');

var rdio = new Rdio({
  clientId: 'oauth2 app client ID',
  clientSecret: 'oauth2 app client secret',
  refreshToken: 'oauth2 user refresh token',
});

rdio.login(function(err) {
  if (err) throw err;
  rdio.call('currentUser', function(err, result) {
    if (err) throw err;
    console.log(result);
  });
});
```

To obtain the oauth2 (refresh) token for your Rdio user:
1. Create an OAuth 2.0 App:
   http://www.rdio.com/developers/
2. Grant your application access to your Rdio user. From your browser, login to Rdio, then open: https&#58;//www.rdio.com/oauth2/authorize?response_type=code&client_id=**APP_CLIENT_ID**&redirect_uri=**APP_REDIRECT_URL**
3. If successful, watch the URL you are being redirected to. It will include a special code= paramater. This is the Authorization Code needed to obtain the Refresh Token.
4. Get the Refresh Token. From the command line:
   curl -d grant_type=authorization_code -d code=**AUTHORIZATION_CODE** -d redirect_uri=**APP_REDIRECT_URL** -d client_id=**APP_CLIENT_ID** -d client_secret=**APP_CLIENT_SECRET** https://services.rdio.com/oauth2/token

On success you will be given a Refresh Token.

I'm proposing that we release this new version under version 2.0.

Finally, I'd like to take over the maintenance of this module. I use Rdio with Node.js every week, and I'd be glad to take over and bring this project back to live! If this is an option, I'm proposing we should also split the "CrunchTune" example into its own repository.
